### PR TITLE
Fix backprop with minibatch

### DIFF
--- a/SparseMax.lua
+++ b/SparseMax.lua
@@ -57,7 +57,7 @@ function SparseMax:updateGradInput(input, gradOutput)
   end
 
   local nonzeros = torch.ne(self.output, 0):typeAs(self.output)
-  local sum = torch.sum(torch.cmul(gradOutput, nonzeros), dim) / torch.sum(nonzeros)
+  local sum = torch.sum(torch.cmul(gradOutput, nonzeros), dim):cdiv(torch.sum(nonzeros, dim))
   self.gradInput = torch.cmul(nonzeros, gradOutput - sum:expandAs(gradOutput))
   return self.gradInput
 end


### PR DESCRIPTION
For minbatch case, each sample should have a different |S(Z)| value. See Eq. (14) in https://arxiv.org/pdf/1602.02068v2.pdf.